### PR TITLE
feat: add parallel price acquisition

### DIFF
--- a/FleaPriceCache.cs
+++ b/FleaPriceCache.cs
@@ -14,7 +14,7 @@ namespace LootValue
 		{
 			bool fleaAvailable = Session.RagFair.Available || LootValueMod.ShowFleaPriceBeforeAccess.Value;
 
-			if (!fleaAvailable || !LootValueMod.EnableFleaQuickSell.Value)
+			if (!fleaAvailable || !LootValueMod.UseFleaPrices.Value)
 				return null;
 
 			if (cache.ContainsKey(templateId))


### PR DESCRIPTION
## Some improvements that were made:
* Added parallel price extraction (if there is an existing request in the pool, it is also processed, which eliminates duplication of such requests);
* Added an explicit setting for forced exclusion of prices from Flea, as well as the ability to use the original method for obtaining the price;
## Explanation:
In the original implementation, when extracting prices, the main flow was blocked, which led to freezes and, as a result, a negative experience of using the mod (especially with _Fika_, #11). In addition, extracting prices from Flea was determined by the parameter "Enable qiuck sale to flea", which is not entirely obvious, so it was moved to a separate setting. In general, you can see for yourself how it works now.
## P.S. The setting for parallel price extraction is disabled by default